### PR TITLE
chore: sync fork

### DIFF
--- a/bio/bbtools/bbduk/environment.yaml
+++ b/bio/bbtools/bbduk/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - nodefaults
 dependencies:
   - bbmap =39.01
-  - snakemake-wrapper-utils =0.5.2
-  - python =3.11.0
+  - snakemake-wrapper-utils =0.5.3
+  - python =3.11.3

--- a/bio/bcftools/merge/environment.yaml
+++ b/bio/bcftools/merge/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bcftools =1.16
-  - snakemake-wrapper-utils =0.5.2
+  - bcftools =1.17
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/bcftools/sort/environment.yaml
+++ b/bio/bcftools/sort/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bcftools =1.16
-  - snakemake-wrapper-utils =0.5.2
+  - bcftools =1.17
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/bismark/bismark2bedGraph/environment.yaml
+++ b/bio/bismark/bismark2bedGraph/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - bowtie2 =2.5.1
   - bismark =0.24.0
-  - samtools =1.16.1
+  - samtools =1.17

--- a/bio/busco/environment.yaml
+++ b/bio/busco/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - busco =5.4.3
+  - busco =5.4.6

--- a/bio/bwa-memx/mem/environment.yaml
+++ b/bio/bwa-memx/mem/environment.yaml
@@ -6,7 +6,7 @@ dependencies:
   - bwa =0.7.17
   - bwa-mem2 =2.2.1
   - bwa-meme =1.0.6
-  - samtools =1.16.1
+  - samtools =1.17
   - samblaster =0.1.26
   - mbuffer =20160228
   - picard-slim =3.0.0

--- a/bio/cutadapt/se/environment.yaml
+++ b/bio/cutadapt/se/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - cutadapt =4.2
+  - cutadapt =4.3

--- a/bio/delly/environment.yaml
+++ b/bio/delly/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - nodefaults
 dependencies:
   - delly =1.1.6
-  - bcftools =1.16
-  - snakemake-wrapper-utils =0.5.2
+  - bcftools =1.17
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/applybqsrspark/environment.yaml
+++ b/bio/gatk/applybqsrspark/environment.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - gatk4 =4.4.0.0
   - snakemake-wrapper-utils =0.5.3
-  - samtools =1.16.1
+  - samtools =1.17

--- a/bio/gatk/baserecalibrator/environment.yaml
+++ b/bio/gatk/baserecalibrator/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4 =4.3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/combinegvcfs/environment.yaml
+++ b/bio/gatk/combinegvcfs/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4 =4.3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/estimatelibrarycomplexity/environment.yaml
+++ b/bio/gatk/estimatelibrarycomplexity/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4 =4.3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/haplotypecaller/environment.yaml
+++ b/bio/gatk/haplotypecaller/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4 =4.3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/gatk/mutect/environment.yaml
+++ b/bio/gatk/mutect/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4 =4.3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - gatk4 =4.4.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/homer/makeTagDirectory/environment.yaml
+++ b/bio/homer/makeTagDirectory/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - homer =4.11
-  - samtools =1.16.1
+  - samtools =1.17

--- a/bio/last/lastdb/environment.yaml
+++ b/bio/last/lastdb/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - last =1452
+  - last =1453

--- a/bio/mashmap/environment.yaml
+++ b/bio/mashmap/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - mashmap =2.0
+  - mashmap =3.0.1
   - gsl =2.7
   - gzip =1.12

--- a/bio/picard/collectgcbiasmetrics/environment.yaml
+++ b/bio/picard/collectgcbiasmetrics/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - picard =3.0.0
-  - snakemake-wrapper-utils =0.5.2
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/picard/sortsam/environment.yaml
+++ b/bio/picard/sortsam/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - picard =2.27.5
-  - snakemake-wrapper-utils =0.5.2
+  - picard =3.0.0
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/qualimap/bamqc/environment.yaml
+++ b/bio/qualimap/bamqc/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - qualimap =2.2.2d
-  - snakemake-wrapper-utils =0.5.2
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/rbt/csvreport/environment.yaml
+++ b/bio/rbt/csvreport/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - rust-bio-tools =0.41.0
+  - rust-bio-tools =0.42.0

--- a/bio/reference/ensembl-variation/environment.yaml
+++ b/bio/reference/ensembl-variation/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - bcftools =1.16
+  - bcftools =1.17
   - curl

--- a/bio/samtools/fixmate/environment.yaml
+++ b/bio/samtools/fixmate/environment.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - samtools =1.16.1
-  - snakemake-wrapper-utils =0.5.2
+  - samtools =1.17
+  - snakemake-wrapper-utils =0.5.3
 name: samtools

--- a/bio/samtools/idxstats/environment.yaml
+++ b/bio/samtools/idxstats/environment.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - samtools =1.16.1
+  - samtools =1.17
   - snakemake-wrapper-utils =0.5.3

--- a/bio/snpsift/genesets/environment.yaml
+++ b/bio/snpsift/genesets/environment.yaml
@@ -4,5 +4,5 @@ channels:
   - nodefaults
 dependencies:
   - snpsift =5.1
-  - bcftools =1.16
-  - snakemake-wrapper-utils =0.5.2
+  - bcftools =1.17
+  - snakemake-wrapper-utils =0.5.3

--- a/bio/umis/bamtag/environment.yaml
+++ b/bio/umis/bamtag/environment.yaml
@@ -4,4 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - umis =1.0.9
-  - samtools =1.16.1
+  - samtools =1.17

--- a/bio/vg/prune/environment.yaml
+++ b/bio/vg/prune/environment.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - vg =1.46.0
+  - vg =1.47.0


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
